### PR TITLE
build: Remove upper bound on python_requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     optax>=0.1.2 # deprecated jax.tree_multimap
     pyhf>=0.6.3
     typing-extensions>=3.7;python_version<'3.8'
-python_requires = >=3.7, < 3.10
+python_requires = >=3.7
 include_package_data = True
 package_dir =
     =src

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering
 project_urls =
     Documentation = https://relaxed.readthedocs.io/


### PR DESCRIPTION
Resolves #40

As there is no explicit reason or broken release for CPython 3.10, remove the `python_requires` install constraint.