### PR TITLE
remove intel macs from CI since jaxopt LBFGS-B does not correctly converge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.11"]
-        runs-on: [ubuntu-latest, macos-latest]
+        runs-on: [ubuntu-latest]
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
When calculating CLs in `test_infer`, the tests consistently get 0.5 for all cases on `macos-latest` only -- I re-ran things to confirm. On `ubuntu-latest` and my local m1 mac, everything works.

I know jaxopt is not tested on `macos-latest`, but this is truly perplexing...

Dropping intel macs from CI to match `jaxopt`, but I'd really like to know what on earth would cause this (not sure if you have any ideas @mblondel...)